### PR TITLE
Fix path to favicon-cheat-sheet.md

### DIFF
--- a/favicon-cheat-sheet.md
+++ b/favicon-cheat-sheet.md
@@ -71,7 +71,7 @@ This README can be executed with tea.xyz.
 
 ```sh
 sh <(curl tea.xyz) \
-  https://github.com/teaxyz/demos/favicon-cheat-sheet.md \
+  https://github.com/teaxyz/demos/blob/main/favicon-cheat-sheet.md \
   input.png
 ```
 


### PR DESCRIPTION
`curl https://raw.githubusercontent.com/teaxyz/demos/favicon-cheat-sheet.md` produces `400: Invalid request`.

Note, this example still doesn't work (https://github.com/teaxyz/demos/issues/1).