### PR TITLE
fix tea invocation

### DIFF
--- a/setup-git-commit-signing.sh
+++ b/setup-git-commit-signing.sh
@@ -44,7 +44,7 @@ tea +crates.io/bpb which -s bpb
 if ! test -f ~/.bpb_keys.toml; then
   #TODO probably we should ask `git` first
 
-  tea +charm.sh/gum format "k first up, we’ll configure your GPG key"
+  tea +charm.sh/gum gum format "k first up, we’ll configure your GPG key"
 
   user=$(tea +charm.sh/gum input "what’s your name?")
   email=$(tea +charm.sh/gum input "what’s your email?")

--- a/setup-git-commit-signing.sh
+++ b/setup-git-commit-signing.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+_="
+---
+args:
+  - bash
+dependencies:
+  gnu.org/bash: '*'
+---
+"
+
 set -e
 
 if ! which -s tea; then


### PR DESCRIPTION
Fixes permissions error when run-by-URL.

```sh
$ tea https://github.com/teaxyz/demos/blob/main/setup-git-commit-signing.sh
error: permission denied (os error 13)
```